### PR TITLE
docs: add task breakdown guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,11 @@ The `pyproject.toml` sections for `ruff` and `mypy` must not be edited without e
 - Do not commit `node_modules` or other large binaries.
 - Heavy ML models should be mocked; see `backend/tests` for examples.
 - Database uses PostgreSQL via SQLAlchemy. Connection string defined in `backend/app/db/session.py`.
+- When creating new tasks, aim for atomic pieces of work that do not overlap so
+  multiple agents can operate in parallel.
+- If such isolation is impossible, explicitly list in the user response which
+  tasks may overlap or depend on one another and note that they must run
+  sequentially.
 
 ## Code Style
 Use Google-style docstrings in English. Functions with more than two arguments


### PR DESCRIPTION
## Summary
- expand notes for future agents about breaking down tasks so they can run in parallel

## Testing
- `uv run ruff check --fix .`
- `uv run ruff format .`
- `uv run mypy .`
- `uv run pytest`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848a6757e60832cb638294f6a673e36