### PR TITLE
Add frontend code style guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,15 @@ The `pyproject.toml` sections for `ruff` and `mypy` must not be edited without e
   sequentially.
 
 ## Code Style
+### Backend
 Use Google-style docstrings in English. Functions with more than two arguments
 must include an ``Args`` section. For complex return types or large functions,
 add a ``Returns`` section. If a function explicitly raises an exception, include
 a ``Raises`` section. API endpoints are exempt because their logic should reside
 in service layers.
+
+### Frontend
+- Write all React components as functional components using hooks.
+- Specify explicit TypeScript prop types for every component.
+- Follow the structure "component – folder – index.tsx" and use CSS modules
+  for styles.


### PR DESCRIPTION
## Summary
- split Code Style section for backend and frontend
- add recommendations for React components

## Testing
- `uv run ruff check --fix .`
- `uv run ruff format .`
- `uv run mypy .`
- `npm run lint`
- `uv run pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848a79316a0832ca9513b37615fa2bd