### PR TITLE
Document compiling protos

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,3 +19,12 @@
 Для локального запуска мок-версий моделей используйте файл `infra/docker-compose.gpu.yml`.
 Он поднимает контейнеры `asr`, `speaker` и `summarizer` с интерфейсом gRPC.
 
+
+## Компиляция proto-файлов
+Для генерации Python-модулей воспользуйтесь пакетом `grpcio-tools`. Запустите команду:
+
+```bash
+python -m grpc_tools.protoc -I ./protos --python_out=./backend/app/protos --grpc_python_out=./backend/app/protos ./protos/*.proto
+```
+
+При необходимости создайте папку `backend/app/protos`. В ней появятся файлы `*_pb2.py` и `*_pb2_grpc.py`, которые затем можно импортировать в коде.


### PR DESCRIPTION
## Summary
- add documentation for compiling protobuf files using `grpcio-tools`

## Testing
- `uv run ruff check --fix .`
- `uv run ruff format .`
- `uv run mypy .`
- `npm run lint`
- `uv run pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848c41a2784832cb229fba86cd8abf6