### PR TITLE
Fix async test execution

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 dev = [
     "mypy>=1.16.0",
     "pytest>=8.4.0",
+    "pytest-asyncio>=0.23.6",
     "ruff>=0.11.13",
 ]
 

--- a/backend/tests/test_grpc_client.py
+++ b/backend/tests/test_grpc_client.py
@@ -1,7 +1,8 @@
 """Tests for mock gRPC clients."""
 
-import asyncio
 from pathlib import Path
+
+import pytest
 
 from app.grpc_client import (
     MockDiarizeClient,
@@ -12,24 +13,27 @@ from app.grpc_client import (
 FIXTURES = Path(__file__).parent / 'fixtures'
 
 
-def test_transcribe_client() -> None:
+@pytest.mark.asyncio
+async def test_transcribe_client() -> None:
     """Client returns transcript from fixture."""
     client = MockTranscribeClient(FIXTURES / 'transcribe.json')
-    result = asyncio.run(client.run(Path('dummy.wav')))
+    result = await client.run(Path('dummy.wav'))
     assert result == {'text': 'hello world'}
 
 
-def test_diarize_client() -> None:
+@pytest.mark.asyncio
+async def test_diarize_client() -> None:
     """Client returns diarization segments from fixture."""
     client = MockDiarizeClient(FIXTURES / 'diarize.json')
-    result = asyncio.run(client.run(Path('dummy.wav')))
+    result = await client.run(Path('dummy.wav'))
     expected_segments = 2
     assert result['segments'][0]['speaker'] == 'A'
     assert len(result['segments']) == expected_segments
 
 
-def test_summarize_client() -> None:
+@pytest.mark.asyncio
+async def test_summarize_client() -> None:
     """Client returns summary from fixture."""
     client = MockSummarizeClient(FIXTURES / 'summarize.json')
-    result = asyncio.run(client.run('some text'))
+    result = await client.run('some text')
     assert result == {'summary': 'This is a summary.'}

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -57,6 +57,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -74,6 +75,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.16.0" },
     { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.6" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
 
@@ -336,6 +338,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976, upload-time = "2025-05-26T04:54:39.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- mark async tests properly
- call async clients with `await`
- install pytest-asyncio to run async tests

## Testing
- `uv run pytest -q`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848c40ecaf8832c940a0af4645d03fe