### PR TITLE
Update AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Instructions for Codex Agents
 
 ## Overview
-This repository contains both backend and frontend code for a local meeting transcription service. All heavy ML models must be mocked in tests.
+This repository contains both backend and frontend code for a local meeting transcription service. All heavy ML models remain mocked in tests.
 
 ## Running Tests
 - Backend tests: run from inside the `backend` directory using `uv run pytest`.
@@ -34,10 +34,13 @@ The `pyproject.toml` sections for `ruff` and `mypy` must not be edited without e
 
 ## Requesting Advanced Research
 If you need additional analysis that exceeds the scope of the repository documentation,
-you may ask the owner to run more capable models: **"o3 pro"** or **"deep research"**.
-Include your question in `QUESTIONS.md` and clearly state which model you are
-requesting. Responses from "o3 pro" usually take about 10–20 minutes while
-"deep research" can take around 20 minutes for a thorough answer.
+you may ask the owner to run more capable models: **"o3"**, **"o3 pro"** or **"deep research"**.
+Responses from "o3" arrive in roughly 1–3 minutes, "o3 pro" in about 10–20 minutes,
+and "deep research" in around 20 minutes. Submit your question in English if you
+want the answer in English and clearly state which model you are requesting.
+Include your question in `QUESTIONS.md` with an empty placeholder where the owner
+can insert the results. Agents without write access may ask the owner directly to
+run the research on their behalf.
 
 Only the repository owner should paste the research outcomes into
 `QUESTIONS.md`. Provide an empty placeholder below your question where the owner
@@ -58,6 +61,7 @@ discussion thread.
 - Heavy ML models should be mocked; see `backend/tests` for examples.
 - Database uses PostgreSQL via SQLAlchemy. Connection string defined in `backend/app/db/session.py`.
 - Apply the repository pattern. Repository classes should reside in `backend/app/database/repositories/`.
+- Instantiate gRPC clients through a factory so tests can swap in mocks easily.
 - When creating new tasks, aim for atomic pieces of work that do not overlap so
   multiple agents can operate in parallel.
 - If such isolation is impossible, explicitly list in the user response which


### PR DESCRIPTION
## Summary
- clarify that heavy models stay mocked in tests
- add gRPC client factory usage guidance
- extend research request instructions with owner note

## Testing
- `uv sync`
- `uv run ruff check --fix .`
- `uv run ruff format .`
- `uv run mypy .`
- `uv run pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6848c436f8a8832c98e67b4518d8c4c5