### PR TITLE
Add gRPC client factory

### DIFF
--- a/backend/tests/test_grpc_client.py
+++ b/backend/tests/test_grpc_client.py
@@ -8,6 +8,7 @@ from app.grpc_client import (
     MockDiarizeClient,
     MockSummarizeClient,
     MockTranscribeClient,
+    create_grpc_client,
 )
 
 FIXTURES = Path(__file__).parent / 'fixtures'
@@ -16,7 +17,8 @@ FIXTURES = Path(__file__).parent / 'fixtures'
 @pytest.mark.asyncio
 async def test_transcribe_client() -> None:
     """Client returns transcript from fixture."""
-    client = MockTranscribeClient(FIXTURES / 'transcribe.json')
+    client = create_grpc_client('transcribe', FIXTURES / 'transcribe.json', 'mock')
+    assert isinstance(client, MockTranscribeClient)
     result = await client.run(Path('dummy.wav'))
     assert result == {'text': 'hello world'}
 
@@ -24,7 +26,8 @@ async def test_transcribe_client() -> None:
 @pytest.mark.asyncio
 async def test_diarize_client() -> None:
     """Client returns diarization segments from fixture."""
-    client = MockDiarizeClient(FIXTURES / 'diarize.json')
+    client = create_grpc_client('diarize', FIXTURES / 'diarize.json', 'mock')
+    assert isinstance(client, MockDiarizeClient)
     result = await client.run(Path('dummy.wav'))
     expected_segments = 2
     assert result['segments'][0]['speaker'] == 'A'
@@ -34,6 +37,15 @@ async def test_diarize_client() -> None:
 @pytest.mark.asyncio
 async def test_summarize_client() -> None:
     """Client returns summary from fixture."""
-    client = MockSummarizeClient(FIXTURES / 'summarize.json')
+    client = create_grpc_client('summarize', FIXTURES / 'summarize.json', 'mock')
+    assert isinstance(client, MockSummarizeClient)
     result = await client.run('some text')
     assert result == {'summary': 'This is a summary.'}
+
+
+@pytest.mark.asyncio
+async def test_factory_uses_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Factory selects client type from environment variable."""
+    monkeypatch.setenv('GRPC_CLIENT_TYPE', 'mock')
+    client = create_grpc_client('transcribe', FIXTURES / 'transcribe.json')
+    assert isinstance(client, MockTranscribeClient)


### PR DESCRIPTION
## Summary
- add factory for selecting gRPC clients
- update tests to verify factory

## Testing
- `uv run ruff check --fix .`
- `uv run ruff format .`
- `uv run mypy .`
- `npm run lint`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848c86d3674832cb34506f7cfd57c7d