### PR TITLE
Update phase 1 implementation plan with repository requirements

### DIFF
--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -85,6 +85,7 @@
    - Meeting (id, user_id, filename, created_at, status)
    - Transcript (id, meeting_id, text, speaker_id, timestamp)
    - User (id, email, created_at)
+   - Репозитории `MeetingRepository`, `TranscriptRepository` и `UserRepository` в `backend/app/database/repositories/`
 
 2. **Настроить Alembic**
    - Инициализация миграций
@@ -95,6 +96,11 @@
    - Создание сессий через SQLAlchemy
    - Dependency injection для database session
    - Обновление тестов с тестовой БД
+   - Обновление сервисов и эндпоинтов для работы через репозитории вместо прямого использования `AsyncSession`
+
+4. **Тестовое покрытие слоя данных**
+   - Написать модульные тесты для репозиториев
+   - Обновить существующие тесты для использования нового слоя доступа к данным
 
 ### Фаза 2: Реальная обработка аудио (1-2 недели)  
 **Приоритет: Высокий**


### PR DESCRIPTION
## Summary
- add a phase 1 subtask to implement repository classes for meetings, transcripts, and users
- clarify that services and endpoints must use repositories instead of AsyncSession directly
- require unit tests for repositories and updates to existing tests for the new data access layer

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d6fc3a586c832c81ae54e2c85caf86