### PR TITLE
Point meeting API to repository raw data directory

### DIFF
--- a/backend/app/api/meeting.py
+++ b/backend/app/api/meeting.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover - used only for type hints
 router = APIRouter()
 
 # Directory for raw audio files.
-RAW_DATA_DIR = Path(__file__).resolve().parents[2] / 'data' / 'raw'
+RAW_DATA_DIR = Path(__file__).resolve().parents[3] / 'data' / 'raw'
 RAW_DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 

--- a/backend/tests/test_api_meeting.py
+++ b/backend/tests/test_api_meeting.py
@@ -19,6 +19,13 @@ if TYPE_CHECKING:  # pragma: no cover - imports for type hints
 client = TestClient(app)
 
 
+def test_raw_data_dir_default_location() -> None:
+    """Default storage path resides under repository data/raw."""
+    raw_dir = meeting.RAW_DATA_DIR
+    assert raw_dir.parts[-2:] == ('data', 'raw')
+    assert raw_dir.is_dir()
+
+
 def test_upload(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Uploading audio saves file and returns meeting id."""
     meeting_id = 'abc123'

--- a/backend/tests/test_api_meeting.py
+++ b/backend/tests/test_api_meeting.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from http import HTTPStatus
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from fastapi.testclient import TestClient
@@ -12,7 +13,6 @@ from app.main import app
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
     from collections.abc import AsyncGenerator
-    from pathlib import Path
 
     import pytest
 
@@ -22,7 +22,9 @@ client = TestClient(app)
 def test_raw_data_dir_default_location() -> None:
     """Default storage path resides under repository data/raw."""
     raw_dir = meeting.RAW_DATA_DIR
-    assert raw_dir.parts[-2:] == ('data', 'raw')
+    repo_root = Path(__file__).resolve().parents[2]
+    assert raw_dir == repo_root / 'data' / 'raw'
+    assert 'backend' not in raw_dir.parts
     assert raw_dir.is_dir()
 
 


### PR DESCRIPTION
## Summary
- update the meeting API to resolve the raw audio directory from the repository root data/raw path
- ensure the raw directory exists on import while keeping tests free to monkeypatch the location
- add coverage that the default raw directory points to data/raw

## Testing
- uv sync
- uv run pytest tests/test_api_meeting.py

------
https://chatgpt.com/codex/tasks/task_e_68d706738328832cabd7e651aae3a81f