### PR TITLE
Implement chunked upload for meeting audio

### DIFF
--- a/backend/app/api/meeting.py
+++ b/backend/app/api/meeting.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:  # pragma: no cover - used only for type hints
 
 router = APIRouter()
 
+CHUNK_SIZE = 1024 * 1024
+
 # Directory for raw audio files.
 RAW_DATA_DIR = Path(__file__).resolve().parents[2] / 'data' / 'raw'
 RAW_DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -26,7 +28,14 @@ async def upload_audio(file: Annotated[UploadFile, File(...)]) -> dict[str, str]
     dest = RAW_DATA_DIR / f'{meeting_id}.wav'
     # TODO: перенести в защищённое хранилище
     with dest.open('wb') as buffer:
-        buffer.write(await file.read())
+        try:
+            while True:
+                chunk = await file.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                buffer.write(chunk)
+        finally:
+            await file.close()
     return {'meeting_id': meeting_id}
 
 

--- a/backend/tests/test_api_meeting.py
+++ b/backend/tests/test_api_meeting.py
@@ -29,11 +29,15 @@ def test_upload(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(meeting, 'uuid4', lambda: _UUID())
     monkeypatch.setattr(meeting, 'RAW_DATA_DIR', tmp_path)
 
-    response = client.post('/upload', files={'file': ('audio.wav', b'data')})
+    monkeypatch.setattr(meeting, 'CHUNK_SIZE', 1024)
+
+    data = bytes(range(256)) * 4096
+
+    response = client.post('/upload', files={'file': ('audio.wav', data)})
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {'meeting_id': meeting_id}
     saved = tmp_path / f'{meeting_id}.wav'
-    assert saved.read_bytes() == b'data'
+    assert saved.read_bytes() == data
 
 
 async def _fake_stream(_: str) -> AsyncGenerator[str, None]:


### PR DESCRIPTION
## Summary
- stream uploaded audio files to disk using fixed-size chunks and ensure uploads close on errors
- extend the meeting upload test to validate chunked writes with larger payloads

## Testing
- uv run pytest tests/test_api_meeting.py::test_upload

------
https://chatgpt.com/codex/tasks/task_e_68d7067455c8832cb1031e5d787b34b6