### PR TITLE
Handle unsupported locales in NextIntl provider

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Root } from './main';
 
@@ -14,6 +14,13 @@ describe('language switch', () => {
     expect(screen.getByRole('heading').textContent).toBe('Войсерек');
     const button = screen.getByTestId('switch');
     await userEvent.click(button);
-    expect(localStorage.getItem('lang')).toBe('en');
+    await waitFor(() => expect(localStorage.getItem('lang')).toBe('en'));
+  });
+
+  it('falls back to English when stored locale is unsupported', async () => {
+    localStorage.setItem('lang', 'de');
+    render(<Root />);
+    expect(screen.getByRole('heading').textContent).toBe('Voicerec');
+    await waitFor(() => expect(localStorage.getItem('lang')).toBe('en'));
   });
 });


### PR DESCRIPTION
## Summary
- compute an effective locale before initializing NextIntlClientProvider and persist it to localStorage
- update the language switch button logic to operate on the effective locale
- cover unsupported stored locales with a vitest case

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7067e1d68832cb73ed1d9206b1c3a