### PR TITLE
Implement lazy database engine initialization

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,8 +1,10 @@
 """Database session helpers."""
 
 from collections.abc import AsyncGenerator
+from typing import Optional
 
 from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
@@ -10,8 +12,53 @@ from sqlalchemy.ext.asyncio import (
 
 from app.core.settings import get_settings
 
-engine = create_async_engine(get_settings().database_url, echo=True)
-AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+_engine: Optional[AsyncEngine] = None
+_engine_url: Optional[str] = None
+_session_factory: Optional[async_sessionmaker[AsyncSession]] = None
+_session_factory_url: Optional[str] = None
+
+
+def get_engine() -> AsyncEngine:
+    """Return a lazily constructed async engine.
+
+    The engine is instantiated on the first call to this function. Subsequent
+    calls reuse the cached engine as long as the connection URL remains
+    unchanged.
+
+    Returns:
+        An ``AsyncEngine`` instance configured with the current database URL.
+    """
+
+    global _engine, _engine_url
+
+    database_url = get_settings().database_url
+    if _engine is None or _engine_url != database_url:
+        _engine = create_async_engine(database_url, echo=True)
+        _engine_url = database_url
+    return _engine
+
+
+def get_session_factory() -> async_sessionmaker[AsyncSession]:
+    """Return a lazily constructed async session factory.
+
+    Returns:
+        An ``async_sessionmaker`` bound to the cached engine.
+    """
+
+    global _session_factory, _session_factory_url
+
+    engine = get_engine()
+    if _session_factory is None or _session_factory_url != _engine_url:
+        _session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        _session_factory_url = _engine_url
+    return _session_factory
+
+
+def AsyncSessionLocal() -> AsyncSession:  # noqa: N802 - preserve existing name
+    """Return an async session using the lazily constructed factory."""
+
+    session_factory = get_session_factory()
+    return session_factory()
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
@@ -20,5 +67,22 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
     Returns:
         An async generator yielding an ``AsyncSession``.
     """
+
     async with AsyncSessionLocal() as session:
         yield session
+
+
+def reset_engine_cache() -> None:
+    """Reset cached engine and session factory instances.
+
+    This helper disposes of the lazy singletons so tests can swap the
+    ``DATABASE_URL`` environment variable before requesting a new session.
+    """
+
+    global _engine, _engine_url, _session_factory, _session_factory_url
+
+    _engine = None
+    _engine_url = None
+    _session_factory = None
+    _session_factory_url = None
+    get_settings.cache_clear()

--- a/backend/tests/test_db_session.py
+++ b/backend/tests/test_db_session.py
@@ -1,0 +1,28 @@
+"""Tests for database session lazy initialization."""
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_async_session_uses_temp_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure temporary DATABASE_URL is respected when requesting a session."""
+
+    temp_url = 'postgresql+asyncpg://user:pass@localhost/temp_db'
+    monkeypatch.setenv('GPU_GRPC_HOST', 'localhost')
+    monkeypatch.setenv('GPU_GRPC_PORT', '1234')
+    monkeypatch.setenv('DATABASE_URL', temp_url)
+    session_module = importlib.import_module('app.db.session')
+    importlib.reload(session_module)
+    session_module.reset_engine_cache()
+
+    try:
+        async with session_module.AsyncSessionLocal() as db_session:
+            bind = db_session.bind
+            assert bind is not None
+            assert bind.url.render_as_string(hide_password=False) == temp_url
+    finally:
+        session_module.reset_engine_cache()


### PR DESCRIPTION
## Summary
- lazy-load the SQLAlchemy async engine and session factory and add a reset helper for tests
- adapt `AsyncSessionLocal` to use the lazy session factory
- add a test that verifies a temporary `DATABASE_URL` is respected

## Testing
- uv run pytest tests/test_db_session.py

------
https://chatgpt.com/codex/tasks/task_e_68d706979d70832c828be5cb5a70ab5a