### PR TITLE
Fix GPU settings initialization and extend tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,13 @@ This repository contains both backend and frontend code for a local meeting tran
 - Frontend tests: `npm test` inside `frontend` directory (uses `vitest`).
 - Always run `uv sync` in the `backend` directory before executing any `uv run` commands or tests. All `uv run` commands must be executed from the `backend` folder and not from the repository root.
 
-Prior to running tests, run code linters and static analysis from the `backend` directory in the following order using `uv run`:
+Prior to running tests, run code linters and static analysis from the `backend` directory in the following order using `uv run` (do this whenever you modify backend code):
 1. `uv run ruff check --fix .`
 2. `uv run ruff format .`
 3. `uv run mypy .` *(execution may take a long time and that is expected)*
 4. `npm run lint` for the frontend.
+
+These linting and type-checking commands are mandatory for every backend code change.
 
 We are adventurers and do not look for easy ways. Do **not** add ignore directives for `mypy` or `ruff`. If an error cannot be solved, add a question in `QUESTIONS.md`.
 

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -54,7 +54,7 @@ class Settings(BaseSettings):
         alias='DATABASE_URL',
         description='Database connection string',
     )
-    gpu: GPUSettings = GPUSettings()
+    gpu: GPUSettings = Field(default_factory=GPUSettings)
 
     model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,8 +1,9 @@
-"""Tests for GPUSettings validators."""
+"""Tests for GPUSettings validators and settings module behavior."""
 
 from __future__ import annotations
 
 import importlib
+from types import ModuleType
 
 import pytest
 from pydantic import ValidationError
@@ -10,10 +11,54 @@ from pydantic import ValidationError
 MODULE_PATH = 'app.core.settings'
 
 
-def _load_gpu_settings() -> type:
+def _reload_settings_module() -> ModuleType:
     module = importlib.import_module(MODULE_PATH)
-    importlib.reload(module)
+    return importlib.reload(module)
+
+
+def _load_gpu_settings() -> type:
+    module = _reload_settings_module()
     return module.GPUSettings
+
+
+def test_settings_module_import_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Settings module can be imported without environment variables set."""
+
+    monkeypatch.delenv('DATABASE_URL', raising=False)
+    monkeypatch.delenv('GPU_GRPC_HOST', raising=False)
+    monkeypatch.delenv('GPU_GRPC_PORT', raising=False)
+
+    module = _reload_settings_module()
+
+    assert hasattr(module, 'Settings')
+
+
+def test_settings_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Creating Settings without the required DATABASE_URL fails validation."""
+
+    monkeypatch.delenv('DATABASE_URL', raising=False)
+    monkeypatch.delenv('GPU_GRPC_HOST', raising=False)
+    monkeypatch.delenv('GPU_GRPC_PORT', raising=False)
+
+    module = _reload_settings_module()
+
+    with pytest.raises(ValidationError):
+        module.Settings()
+
+
+def test_get_settings_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_settings returns the same instance on repeated calls."""
+
+    monkeypatch.setenv('DATABASE_URL', 'postgresql://example')
+    monkeypatch.setenv('GPU_GRPC_HOST', 'host')
+    monkeypatch.setenv('GPU_GRPC_PORT', '1234')
+
+    module = _reload_settings_module()
+
+    first = module.get_settings()
+    second = module.get_settings()
+
+    assert first is second
 
 
 def test_tls_requires_certificates(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import importlib
-from types import ModuleType
+from typing import TYPE_CHECKING
 
 import pytest
 from pydantic import ValidationError
 
 MODULE_PATH = 'app.core.settings'
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 def _reload_settings_module() -> ModuleType:
@@ -23,7 +26,6 @@ def _load_gpu_settings() -> type:
 
 def test_settings_module_import_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Settings module can be imported without environment variables set."""
-
     monkeypatch.delenv('DATABASE_URL', raising=False)
     monkeypatch.delenv('GPU_GRPC_HOST', raising=False)
     monkeypatch.delenv('GPU_GRPC_PORT', raising=False)
@@ -35,7 +37,6 @@ def test_settings_module_import_without_env(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_settings_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
     """Creating Settings without the required DATABASE_URL fails validation."""
-
     monkeypatch.delenv('DATABASE_URL', raising=False)
     monkeypatch.delenv('GPU_GRPC_HOST', raising=False)
     monkeypatch.delenv('GPU_GRPC_PORT', raising=False)
@@ -48,7 +49,6 @@ def test_settings_requires_database_url(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_get_settings_is_cached(monkeypatch: pytest.MonkeyPatch) -> None:
     """get_settings returns the same instance on repeated calls."""
-
     monkeypatch.setenv('DATABASE_URL', 'postgresql://example')
     monkeypatch.setenv('GPU_GRPC_HOST', 'host')
     monkeypatch.setenv('GPU_GRPC_PORT', '1234')


### PR DESCRIPTION
## Summary
- delay GPU settings instantiation using a default factory in the settings model
- extend settings tests to cover module import without environment variables, validation errors, and cached getters

## Testing
- uv run pytest tests/test_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68d706a70920832c8790ff08bdfa63a1