### PR TITLE
Localize dialog close button label and extend language tests

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -23,4 +23,23 @@ describe('language switch', () => {
     expect(screen.getByRole('heading').textContent).toBe('Voicerec');
     await waitFor(() => expect(localStorage.getItem('lang')).toBe('en'));
   });
+
+  it('updates close button text when language changes', async () => {
+    render(<Root />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open Dialog' }));
+    const closeButtonEn = await screen.findByRole('button', { name: 'Close' });
+    expect(closeButtonEn.textContent).toBe('Close');
+
+    await userEvent.click(closeButtonEn);
+
+    await userEvent.click(screen.getByTestId('switch'));
+    await waitFor(() =>
+      expect(screen.getByRole('heading').textContent).toBe('Войсерек')
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Открыть диалог' }));
+    const closeButtonRu = await screen.findByRole('button', { name: 'Закрыть' });
+    expect(closeButtonRu.textContent).toBe('Закрыть');
+  });
 });

--- a/frontend/src/components/Dialog/index.tsx
+++ b/frontend/src/components/Dialog/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { useTranslations } from 'next-intl';
 import styles from './styles.module.css';
 
 type DialogProps = React.ComponentProps<typeof DialogPrimitive.Root> & {
@@ -8,6 +9,8 @@ type DialogProps = React.ComponentProps<typeof DialogPrimitive.Root> & {
 };
 
 export function Dialog({ triggerText, children, ...props }: DialogProps) {
+  const t = useTranslations();
+
   return (
     <DialogPrimitive.Root {...props}>
       <DialogPrimitive.Trigger className={styles.trigger}>
@@ -18,7 +21,7 @@ export function Dialog({ triggerText, children, ...props }: DialogProps) {
         <DialogPrimitive.Content className={styles.content}>
           {children}
           <DialogPrimitive.Close className={styles.close}>
-            Close
+            {t('closeDialog')}
           </DialogPrimitive.Close>
         </DialogPrimitive.Content>
       </DialogPrimitive.Portal>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,5 +1,6 @@
 {
   "title": "Voicerec",
   "openDialog": "Open Dialog",
-  "dialogText": "Hello world"
+  "dialogText": "Hello world",
+  "closeDialog": "Close"
 }

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -1,5 +1,6 @@
 {
   "title": "Войсерек",
   "openDialog": "Открыть диалог",
-  "dialogText": "Привет, мир"
+  "dialogText": "Привет, мир",
+  "closeDialog": "Закрыть"
 }


### PR DESCRIPTION
## Summary
- use next-intl to translate the dialog close button label
- add the closeDialog message for English and Russian locales
- extend the language switch test to assert the close button text updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d70c1d03bc832ca8aa39e70a79f92f