### PR TITLE
Fix dialog localization to rely on internal i18n

### DIFF
--- a/frontend/src/components/Dialog/index.tsx
+++ b/frontend/src/components/Dialog/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { useTranslations } from '../../i18n';
 import styles from './styles.module.css';
 
 type DialogProps = React.ComponentProps<typeof DialogPrimitive.Root> & {
@@ -8,6 +9,8 @@ type DialogProps = React.ComponentProps<typeof DialogPrimitive.Root> & {
 };
 
 export function Dialog({ triggerText, children, ...props }: DialogProps) {
+  const t = useTranslations();
+
   return (
     <DialogPrimitive.Root {...props}>
       <DialogPrimitive.Trigger className={styles.trigger}>
@@ -18,7 +21,7 @@ export function Dialog({ triggerText, children, ...props }: DialogProps) {
         <DialogPrimitive.Content className={styles.content}>
           {children}
           <DialogPrimitive.Close className={styles.close}>
-            Close
+            {t('closeDialog')}
           </DialogPrimitive.Close>
         </DialogPrimitive.Content>
       </DialogPrimitive.Portal>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,5 +1,6 @@
 {
   "title": "Voicerec",
   "openDialog": "Open Dialog",
-  "dialogText": "Hello world"
+  "dialogText": "Hello world",
+  "closeDialog": "Close"
 }

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -1,5 +1,6 @@
 {
   "title": "Войсерек",
   "openDialog": "Открыть диалог",
-  "dialogText": "Привет, мир"
+  "dialogText": "Привет, мир",
+  "closeDialog": "Закрыть"
 }


### PR DESCRIPTION
## Summary
- update the Dialog component to consume the app's translation hook instead of the Next.js-specific package
- translate the close button label using the existing locale JSON files

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d714afc454832ca3be74668c06980f