### PR TITLE
Fix dialog translations import

### DIFF
--- a/frontend/src/components/Dialog/index.tsx
+++ b/frontend/src/components/Dialog/index.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 
 import { useTranslations } from '../../i18n';
-=======
-import { useTranslations } from 'next-intl';
 
 import styles from './styles.module.css';
 


### PR DESCRIPTION
## Summary
- resolve the merge conflict in the dialog component by using the local translation hook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d715feff60832c8ea9f253a6784f6c