### PR TITLE
Add PostgreSQL docker compose files for development and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ environment variables.
 ## Mock GPU Services
 `infra/docker-compose.gpu.yml` launches CPU-only mock containers that emulate the GPU-backed models. Run `docker compose -f infra/docker-compose.gpu.yml up` during development to start `asr`, `speaker`, and `summarizer` services locally.
 
+## PostgreSQL Containers
+Use Docker Compose to start a local PostgreSQL instance with credentials that match the default `.env` configuration:
+
+```bash
+docker compose -f infra/docker-compose.dev.yml up -d postgres
+```
+
+Continuous integration environments can reuse the stripped-down definition:
+
+```bash
+docker compose -f infra/docker-compose.ci.yml up -d postgres
+```
+
+Both configurations expose the `voicerec` database and ship with health checks based on `pg_isready`.
+
 ## Next Steps
 1. Flesh out endpoints for uploading audio and returning transcripts.
 2. Add authentication and database models.

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@
 | D1 | ✗ | Обновить доку (process_overview/README/CONTEXT): логирование, маршруты, хранилище аудио, модели/репозитории, тест-инфра | Docs | P1 | B1–B3, A1–A3, L1, T1 |
 | A4 | ✗ | Починить дефолтный бэкенд-стриминг SSE: `TranscriptService.stream_transcript` должен возвращать `AsyncIterable`; корректный `_event_generator`, heartbeat/timeout | Backend/API/SSE | P1 | S1 |
 | D2 | ✗ | Синхронизировать пути в плане с деревом проекта: `backend/app/db/...` вместо `backend/app/database/...`; убрать ссылки на несуществующие тесты/каталоги | Docs/Plan | P1 | — |
-| I1 | ✗ | Добавить PostgreSQL в docker-compose (dev/CI), базовые параметры и healthchecks | Infra | P1 | — |
+| I1 | ✓ | Добавить PostgreSQL в docker-compose (dev/CI), базовые параметры и healthchecks | Infra | P1 | — |
 | F2 | ✗ | Почистить фронтенд-зависимости, обновить lock/README, добавить vitest smoke-snapshot | Frontend/Build | P2 | — |
 | T2 | ✗ | Убрать `sys.path.append` из тестов: оформить backend как installable package или корректно настроить PYTHONPATH/uv; обновить инструкции | Tests/Infra | P2 | — |
 | F3 | ✗ | Локализовать кнопку “Close” в диалоге (i18n словари, переключение языка) | Frontend/i18n | P2 | — |

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,21 @@
 Все исходные аудио сохраняются во временную папку `data/raw/`. Эти файлы нужно
 перенести в защищённое хранилище до конца 2025 года.
 
+## PostgreSQL
+Для разработки поднимите локальную базу данных командой:
+
+```bash
+docker compose -f infra/docker-compose.dev.yml up -d postgres
+```
+
+В CI используйте облегчённую конфигурацию:
+
+```bash
+docker compose -f infra/docker-compose.ci.yml up -d postgres
+```
+
+Обе конфигурации создают базу `voicerec` с пользователем `voicerec` и включённым healthcheck на основе `pg_isready`.
+
 ## Компиляция proto-файлов
 Для генерации Python-модулей воспользуйтесь пакетом `grpcio-tools`. Запустите команду:
 

--- a/docs/ai-context/project-structure.md
+++ b/docs/ai-context/project-structure.md
@@ -138,6 +138,8 @@ Voicerec-By-Codex/
 ├── protos/                             # Protocol buffer definitions
 │   └── [proto files]                   # gRPC service definitions
 ├── infra/                              # Infrastructure configuration
+│   ├── docker-compose.ci.yml           # PostgreSQL service for CI pipelines
+│   ├── docker-compose.dev.yml          # PostgreSQL service for local development
 │   └── docker-compose.gpu.yml          # Mock GPU services configuration
 ├── data/                               # Data storage (temporary)
 │   └── raw/                            # Raw audio storage (migrate by 2025)

--- a/infra/docker-compose.ci.yml
+++ b/infra/docker-compose.ci.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: voicerec-postgres-ci
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: voicerec
+      POSTGRES_PASSWORD: voicerec
+      POSTGRES_DB: voicerec
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U voicerec -d voicerec"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,0 +1,23 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: voicerec-postgres-dev
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: voicerec
+      POSTGRES_PASSWORD: voicerec
+      POSTGRES_DB: voicerec
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U voicerec -d voicerec"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+volumes:
+  postgres_data:
+    driver: local


### PR DESCRIPTION
## Summary
- add PostgreSQL services to new development and CI Docker Compose definitions with health checks
- document how to start the Postgres containers in the root README and docs overview
- update the project structure overview and mark task I1 as completed in TODO.md

## Testing
- not run (documentation and configuration changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d71c831c1c832c8c8846760a33e02e