### PR TITLE
Replace custom i18n provider with react-intl

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@
 | F2 | ✓ | Почистить фронтенд-зависимости, обновить lock/README, добавить vitest smoke-snapshot | Frontend/Build | P2 | — |
 | T2 | ✓ | Убрать `sys.path.append` из тестов: оформить backend как installable package или корректно настроить PYTHONPATH/uv; обновить инструкции | Tests/Infra | P2 | — |
 | F3 | ✓ | Локализовать кнопку “Close” в диалоге (i18n словари, переключение языка) | Frontend/i18n | P2 | — |
-| F4 | ✗ | Заменить `next-intl` на Vite-дружелюбную i18n-библиотеку (напр., `react-intl`/`use-intl`/`lingui`) | Frontend/i18n | P2 | F2 |
+| F4 | ✓ | Заменить `next-intl` на Vite-дружелюбную i18n-библиотеку (напр., `react-intl`/`use-intl`/`lingui`) | Frontend/i18n | P2 | F2 |
 
 ## Предлагаемые параллельные треки
 

--- a/frontend/CONTEXT.md
+++ b/frontend/CONTEXT.md
@@ -4,7 +4,7 @@
 React-based web application for meeting transcription interface. Provides audio upload, real-time transcript display, speaker identification visualization, and meeting management. Built with TypeScript, Vite, Radix UI primitives, and CSS modules.
 
 ## Current Status: Initial Setup
-Frontend scaffolding established with React 18, TypeScript, and Vite. Basic component structure with App and Dialog components. Internationalization support with English and Russian locales via a lightweight custom provider. Styling relies on CSS modules alongside Radix UI for accessible primitives.
+Frontend scaffolding established with React 18, TypeScript, and Vite. Basic component structure with App and Dialog components. Internationalization support with English and Russian locales powered by `react-intl`. Styling relies on CSS modules alongside Radix UI for accessible primitives.
 
 ## Component-Specific Development Guidelines
 
@@ -54,8 +54,8 @@ components/
 - **WebSocket** for real-time updates
 
 ### Internationalization (`src/locales/`)
-- Custom React translation provider (`src/i18n`)
-- JSON files for translations
+- `react-intl` provider wrapper (`src/i18n`)
+- JSON files for translations consumed by `IntlProvider`
 - Support for English and Russian
 
 ## Architectural Patterns

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-intl": "^7.1.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
@@ -23,8 +24,8 @@
     "eslint": "^9.0.0",
     "jsdom": "^26.1.0",
     "typescript": "^5.0.0",
+    "typescript-eslint": "^8.24.0",
     "vite": "^5.0.0",
-    "vitest": "^3.2.3",
-    "typescript-eslint": "^8.24.0"
+    "vitest": "^3.2.3"
   }
 }


### PR DESCRIPTION
## Summary
- integrate `react-intl` as the frontend i18n library and wrap translations with typed hooks
- refresh frontend context docs and mark TODO F4 as completed

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d72c402aa0832c938aaad3834318bc