### PR TITLE
Handle missing meeting audio when streaming transcripts

### DIFF
--- a/backend/app/services/transcript.py
+++ b/backend/app/services/transcript.py
@@ -24,6 +24,15 @@ class TranscriptClientProtocol(Protocol):
         """Return transcript payload for the provided audio source."""
 
 
+class MeetingNotFoundError(Exception):
+    """Raised when requested meeting audio file is missing."""
+
+    def __init__(self, meeting_id: str) -> None:
+        message = f'Meeting {meeting_id} not found'
+        super().__init__(message)
+        self.meeting_id = meeting_id
+
+
 class TranscriptService:
     """Stream transcript fragments for SSE consumption."""
 
@@ -58,11 +67,22 @@ class TranscriptService:
         Yields:
             Dictionaries with chunk metadata and text content.
         """
-        audio_path = self._raw_audio_dir / f'{meeting_id}.wav'
+        audio_path = self._resolve_audio_path(meeting_id)
         payload = await self._client.run(audio_path)
 
         for index, chunk in enumerate(self._extract_chunks(payload), start=1):
             yield {'index': index, 'text': chunk}
+
+    def ensure_audio_available(self, meeting_id: str) -> None:
+        """Validate that raw audio exists for the provided meeting identifier."""
+        self._resolve_audio_path(meeting_id)
+
+    def _resolve_audio_path(self, meeting_id: str) -> Path:
+        """Return audio file path and ensure it exists."""
+        audio_path = self._raw_audio_dir / f'{meeting_id}.wav'
+        if not audio_path.is_file():
+            raise MeetingNotFoundError(meeting_id)
+        return audio_path
 
     def _extract_chunks(self, payload: dict[str, Any]) -> Iterable[str]:
         """Extract text chunks from transcription payload."""

--- a/backend/tests/test_api_meeting.py
+++ b/backend/tests/test_api_meeting.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Any, Self
 
 from fastapi.testclient import TestClient
 
 from app.api import meeting
 from app.main import app
-from app.services.transcript import get_transcript_service
+from app.services.transcript import TranscriptService, get_transcript_service
 
 if TYPE_CHECKING:  # pragma: no cover - imports for type hints
     from collections.abc import AsyncGenerator
@@ -175,6 +175,9 @@ def test_stream() -> None:
         def __init__(self) -> None:
             self.calls: list[str] = []
 
+        def ensure_audio_available(self, meeting_id: str) -> None:
+            del meeting_id
+
         async def stream_transcript(
             self, meeting_id: str
         ) -> AsyncGenerator[dict[str, int | str], None]:
@@ -200,3 +203,28 @@ def test_stream() -> None:
         'data: {}',
     ]
     assert fake_service.calls == ['xyz']
+
+
+def test_stream_missing_meeting_returns_404(tmp_path: Path) -> None:
+    """Missing meeting audio results in 404 without invoking transcript client."""
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.calls: list[Path] = []
+
+        async def run(self, source: Path) -> dict[str, Any]:
+            self.calls.append(source)
+            return {'segments': [{'text': 'should not be used'}]}
+
+    fake_client = _FakeClient()
+    service = TranscriptService(fake_client, raw_audio_dir=tmp_path)
+    app.dependency_overrides[get_transcript_service] = lambda: service
+
+    try:
+        response = client.get('/stream/missing')
+    finally:
+        app.dependency_overrides.pop(get_transcript_service, None)
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert response.json() == {'detail': 'Meeting missing not found'}
+    assert fake_client.calls == []


### PR DESCRIPTION
## Summary
- add a domain-specific MeetingNotFoundError and ensure the transcript service validates audio availability before invoking the client
- translate missing meeting errors in the streaming endpoint into 404 HTTP responses
- cover the missing-meeting scenario with an API test that asserts both the 404 response and the absence of client calls

## Testing
- uv run ruff check --fix .
- uv run ruff format .
- uv run mypy .
- uv run pytest tests/test_api_meeting.py

------
https://chatgpt.com/codex/tasks/task_e_68d72cc4ebe4832c98edf6460efd971b