### PR TITLE
Add async SQLite test infrastructure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 | B1 | ✓ | Базовая ORM-инфраструктура: `DeclarativeBase`, `metadata`, точка импорта моделей | Backend/DB | P0 | — |
 | B2 | ✗ | Модели **User, Meeting, Transcript** с связями/индексами | Backend/DB | P0 | B1 |
 | B3 | ✗ | Репозитории (CRUD) в `app/db/repositories/` (или единый слой данных) | Backend/DB | P0 | B1–B2 |
-| T1 | ✗ | Async тестовая БД (SQLite/aiosqlite), фикстуры, создание/очистка схемы, FastAPI overrides | Tests/Infra | P0 | B1 |
+| T1 | ✓ | Async тестовая БД (SQLite/aiosqlite), фикстуры, создание/очистка схемы, FastAPI overrides | Tests/Infra | P0 | B1 |
 | A2 | ✓ | `/upload`: асинхронная потоковая запись чанками + проверка MIME; негативные/large-file тесты | Backend/API | P0 | — |
 | S1 | ✗ | Вынести `TranscriptService` в сервисный слой и внедрять через DI (FastAPI Depends); принимать `AsyncSession` и (в будущем) gRPC-клиентов | Backend/Services | P0 | B1–B3, T1 |
 | A1 | ✗ | Выровнять маршруты с докой: префикс `/api/meeting` для upload/stream + подключение роутера | Backend/API | P1 | — |

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.13"
 dependencies = [
     "asyncpg>=0.30.0",
     "aiofiles>=24.1.0",
+    "aiosqlite>=0.20.0",
     "fastapi>=0.115.12",
     "python-multipart>=0.0.7",
     "httpx>=0.28.1",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,1 +1,143 @@
-"""Test configuration."""
+"""Test configuration and shared fixtures."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+
+from app.db.base import Base, import_model_modules
+from app.db.session import get_session, reset_engine_cache
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from fastapi import FastAPI
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _build_sqlite_url(database_path: str) -> str:
+    """Return SQLite database URL for the provided file path."""
+    return f'sqlite+aiosqlite:///{database_path}'
+
+
+@pytest.fixture
+def sqlite_test_url(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """Return unique SQLite database URL for the current test function."""
+    database_dir = tmp_path_factory.mktemp('sqlite-db')
+    database_path = database_dir / 'database.db'
+    return _build_sqlite_url(database_path.as_posix())
+
+
+@pytest_asyncio.fixture
+async def db_engine(sqlite_test_url: str) -> AsyncIterator[AsyncEngine]:
+    """Create a fresh async SQLite engine with initialized schema."""
+    previous_database_url = os.environ.get('DATABASE_URL')
+    previous_gpu_host = os.environ.get('GPU_GRPC_HOST')
+    previous_gpu_port = os.environ.get('GPU_GRPC_PORT')
+
+    os.environ['DATABASE_URL'] = sqlite_test_url
+    os.environ.setdefault('GPU_GRPC_HOST', 'localhost')
+    os.environ.setdefault('GPU_GRPC_PORT', '50051')
+
+    reset_engine_cache()
+    import_model_modules()
+
+    engine = create_async_engine(sqlite_test_url)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    try:
+        yield engine
+    finally:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+        reset_engine_cache()
+
+        if previous_database_url is not None:
+            os.environ['DATABASE_URL'] = previous_database_url
+        else:
+            os.environ.pop('DATABASE_URL', None)
+
+        if previous_gpu_host is not None:
+            os.environ['GPU_GRPC_HOST'] = previous_gpu_host
+        else:
+            os.environ.pop('GPU_GRPC_HOST', None)
+
+        if previous_gpu_port is not None:
+            os.environ['GPU_GRPC_PORT'] = previous_gpu_port
+        else:
+            os.environ.pop('GPU_GRPC_PORT', None)
+
+
+@pytest.fixture
+def session_factory(
+    db_engine: AsyncEngine,
+) -> async_sessionmaker[AsyncSession]:
+    """Return async session factory bound to the temporary engine."""
+    return async_sessionmaker(db_engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture
+async def db_session(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncIterator[AsyncSession]:
+    """Provide a transactional session rolled back after each test."""
+    async with session_factory() as session:
+        try:
+            yield session
+        finally:
+            await session.rollback()
+
+
+@pytest.fixture
+def fastapi_app(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> Iterator[FastAPI]:
+    """Return FastAPI application with database dependency overridden."""
+    from app.main import app
+
+    async def _override_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            try:
+                yield session
+            finally:
+                await session.rollback()
+
+    app.dependency_overrides[get_session] = _override_session
+
+    try:
+        yield app
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+
+
+@pytest_asyncio.fixture
+async def fastapi_db_session(fastapi_app: FastAPI) -> AsyncIterator[AsyncSession]:
+    """Yield a database session using the FastAPI override for convenience."""
+    override = fastapi_app.dependency_overrides[get_session]
+    generator = override()
+
+    try:
+        session = await generator.__anext__()
+    except StopAsyncIteration:  # pragma: no cover - defensive safeguard
+        message = 'Database override did not yield a session'
+        raise RuntimeError(message) from None
+
+    try:
+        yield session
+    finally:
+        await generator.aclose()
+
+
+@pytest_asyncio.fixture
+async def verify_database_ready(db_session: AsyncSession) -> None:
+    """Ensure the transient database is reachable before running dependent tests."""
+    result = await db_session.execute(text('SELECT 1'))
+    assert result.scalar_one() == 1

--- a/backend/tests/test_db_fixtures.py
+++ b/backend/tests/test_db_fixtures.py
@@ -1,0 +1,45 @@
+"""Tests for asynchronous database fixtures."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import text
+
+from app.db.session import get_session
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_db_session_fixture_executes_simple_query(db_session: AsyncSession) -> None:
+    """The standalone database session fixture can execute basic SQL."""
+    result = await db_session.execute(text('SELECT 1'))
+    assert result.scalar_one() == 1
+
+
+@pytest.mark.asyncio
+async def test_fastapi_db_override_yields_independent_sessions(fastapi_app: FastAPI) -> None:
+    """FastAPI dependency override provides separate sessions per request."""
+    override = fastapi_app.dependency_overrides[get_session]
+
+    first_generator = override()
+    second_generator = override()
+
+    first_session = await first_generator.__anext__()
+    second_session = await second_generator.__anext__()
+
+    try:
+        assert first_session is not second_session
+
+        result = await first_session.execute(text('SELECT 1'))
+        assert result.scalar_one() == 1
+
+        result = await second_session.execute(text('SELECT 1'))
+        assert result.scalar_one() == 1
+    finally:
+        await first_generator.aclose()
+        await second_generator.aclose()


### PR DESCRIPTION
## Summary
- add async SQLite fixtures to pytest configuration and FastAPI overrides
- add dedicated tests to validate the async database fixtures
- add the aiosqlite dependency and mark the TODO entry as complete

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d72c337738832cb4068c83f7c89e48