### PR TITLE
Expose Postgres port in CI compose definition

### DIFF
--- a/infra/docker-compose.ci.yml
+++ b/infra/docker-compose.ci.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_USER: voicerec
       POSTGRES_PASSWORD: voicerec
       POSTGRES_DB: voicerec
+    ports:
+      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U voicerec -d voicerec"]
       interval: 10s


### PR DESCRIPTION
## Summary
- publish the PostgreSQL 5432 port from the CI docker-compose service so host-based jobs can connect

## Testing
- not run (infra-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d749ab2fb4832c83d1fc37cd1ea7aa