### PR TITLE
Fix backend dependency installer

### DIFF
--- a/scripts/install_backend_deps.sh
+++ b/scripts/install_backend_deps.sh
@@ -7,7 +7,6 @@ BACKEND_DIR="$REPO_ROOT/backend"
 if [ -f "$BACKEND_DIR/pyproject.toml" ]; then
   (cd "$BACKEND_DIR" && \
     uv venv && \
-    uv lock && \
-    uv sync --frozen && \
+    uv sync && \
     uv pip install -e .)
 fi


### PR DESCRIPTION
## Summary
- stop running `uv lock` during backend dependency installation
- allow `uv sync` to create the lock file by removing the `--frozen` flag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d74a0c5fb0832c846b6f22092a5226