### PR TITLE
Update transcript stream endpoint usage

### DIFF
--- a/frontend/src/components/TranscriptStream/TranscriptStream.test.tsx
+++ b/frontend/src/components/TranscriptStream/TranscriptStream.test.tsx
@@ -71,7 +71,7 @@ describe('TranscriptStream', () => {
     renderWithIntl(<TranscriptStream meetingId="meeting-42" eventSourceFactory={factory} />);
 
     expect(MockEventSource.instances).toHaveLength(1);
-    expect(MockEventSource.instances[0].url).toBe('/api/meeting/stream/meeting-42');
+    expect(MockEventSource.instances[0].url).toBe('/api/meeting/meeting-42/stream');
     expect(
       screen.getByText('Connecting to live transcript…', { exact: false })
     ).toBeTruthy();
@@ -134,5 +134,22 @@ describe('TranscriptStream', () => {
     } else {
       delete globalWindow.EventSource;
     }
+  });
+
+  it('creates a meeting-specific stream endpoint on meeting change', async () => {
+    const factory = ((url: string) => new MockEventSource(url)) as EventSourceFactory;
+    const { rerender } = renderWithIntl(
+      <TranscriptStream meetingId="meeting-1" eventSourceFactory={factory} />,
+    );
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe('/api/meeting/meeting-1/stream');
+
+    await act(async () => {
+      rerender(<TranscriptStream meetingId="meeting-2" eventSourceFactory={factory} />);
+    });
+
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(MockEventSource.instances[1].url).toBe('/api/meeting/meeting-2/stream');
   });
 });

--- a/frontend/src/components/TranscriptStream/index.tsx
+++ b/frontend/src/components/TranscriptStream/index.tsx
@@ -77,7 +77,7 @@ export default function TranscriptStream({
       return undefined;
     }
 
-    const source = factory(`/api/meeting/stream/${meetingId}`);
+    const source = factory(`/api/meeting/${meetingId}/stream`);
     let isActive = true;
 
     setChunks([]);


### PR DESCRIPTION
## Summary
- update the transcript stream component to call the new `/api/meeting/{meetingId}/stream` endpoint
- extend component tests to validate URL construction for initial render and meeting changes

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d7518ed20c832c9c917f98b38c33e0