### PR TITLE
Handle transcript and summary SSE events separately

### DIFF
--- a/frontend/src/components/TranscriptStream/TranscriptStream.test.tsx
+++ b/frontend/src/components/TranscriptStream/TranscriptStream.test.tsx
@@ -4,39 +4,67 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import { TranslationProvider, Locale } from '../../i18n';
 import TranscriptStream, { EventSourceFactory } from './index';
 
+/* eslint-disable-next-line no-unused-vars */
+type GenericListener = (payload: unknown) => void;
+
 class MockEventSource {
   public static instances: MockEventSource[] = [];
   public readonly url: string;
   public onopen: (() => void) | null = null;
-  public onmessage: ((data: string) => void) | null = null; // eslint-disable-line no-unused-vars
   public onerror: (() => void) | null = null;
   private closed = false;
+  private readonly listeners: Record<string, Set<GenericListener>> = {};
 
   constructor(url: string) {
     this.url = url;
     MockEventSource.instances.push(this);
   }
 
-  emitOpen() {
-    if (this.closed) {
-      return;
+  addEventListener(type: string, listener: GenericListener) {
+    if (!this.listeners[type]) {
+      this.listeners[type] = new Set();
     }
-    this.onopen?.({});
+    this.listeners[type].add(listener);
   }
 
-  emitMessage(payload: unknown) {
+  removeEventListener(type: string, listener: GenericListener) {
+    this.listeners[type]?.delete(listener);
+    if (this.listeners[type] && this.listeners[type]?.size === 0) {
+      delete this.listeners[type];
+    }
+  }
+
+  private emit(type: string, payload: unknown) {
     if (this.closed) {
       return;
     }
     const data = typeof payload === 'string' ? payload : JSON.stringify(payload);
-    this.onmessage?.(data);
+    const event = { data };
+    this.listeners[type]?.forEach((listener) => {
+      listener(event);
+    });
+  }
+
+  emitOpen() {
+    if (this.closed) {
+      return;
+    }
+    this.onopen?.();
+  }
+
+  emitTranscript(payload: unknown) {
+    this.emit('transcript', payload);
+  }
+
+  emitSummary(payload: unknown) {
+    this.emit('summary', payload);
   }
 
   emitError() {
     if (this.closed) {
       return;
     }
-    this.onerror?.({});
+    this.onerror?.();
   }
 
   close(): void {
@@ -87,7 +115,7 @@ describe('TranscriptStream', () => {
     );
 
     await act(async () => {
-      MockEventSource.instances[0].emitMessage({
+      MockEventSource.instances[0].emitTranscript({
         id: 'chunk-1',
         text: 'Добро пожаловать',
         speaker: 'Speaker 1',
@@ -98,6 +126,17 @@ describe('TranscriptStream', () => {
     expect(transcriptItem.textContent?.replace(/\s+/g, ' ').trim()).toBe(
       'Speaker 1: Добро пожаловать',
     );
+
+    await act(async () => {
+      MockEventSource.instances[0].emitSummary({
+        summary: 'Основные итоги встречи',
+      });
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 3, name: 'Meeting summary' })
+    ).toBeTruthy();
+    expect(screen.getByText('Основные итоги встречи')).toBeTruthy();
   });
 
   it('shows an error status when the stream fails', async () => {

--- a/frontend/src/components/TranscriptStream/styles.module.css
+++ b/frontend/src/components/TranscriptStream/styles.module.css
@@ -57,3 +57,20 @@
   font-size: 0.95rem;
   color: #4b5563;
 }
+
+.summarySection {
+  border-top: 1px solid #e5e7eb;
+  padding-top: 1rem;
+}
+
+.summaryTitle {
+  margin: 0 0 0.5rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.summaryText {
+  margin: 0;
+  line-height: 1.6;
+  color: #1f2933;
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -8,5 +8,6 @@
   "transcriptStream.status.open": "Live transcription in progress",
   "transcriptStream.status.error": "Connection lost. Please retry.",
   "transcriptStream.status.unsupported": "Live transcript is unavailable in this environment.",
-  "transcriptStream.empty": "Waiting for transcript updates…"
+  "transcriptStream.empty": "Waiting for transcript updates…",
+  "transcriptStream.summary.title": "Meeting summary"
 }

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -8,5 +8,6 @@
   "transcriptStream.status.open": "Транскрипция в реальном времени активна",
   "transcriptStream.status.error": "Соединение потеряно. Повторите попытку.",
   "transcriptStream.status.unsupported": "Поток транскрипции недоступен в этом окружении.",
-  "transcriptStream.empty": "Ожидание новых фрагментов транскрипции…"
+  "transcriptStream.empty": "Ожидание новых фрагментов транскрипции…",
+  "transcriptStream.summary.title": "Итоговое резюме"
 }


### PR DESCRIPTION
## Summary
- register explicit SSE listeners for transcript and summary events, parsing payloads into dedicated transcript and summary state
- render the streamed meeting summary beneath the transcript list and style the new section
- extend the mock EventSource and tests to cover both event types and add localization strings for the summary heading

## Testing
- npm run lint
- npm test -- run src/components/TranscriptStream/TranscriptStream.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7519345ec832c9436505ab0cb8455