### PR TITLE
Align default schema version with latest Alembic revision

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_RAW_AUDIO_DIR = REPO_ROOT / 'data' / 'raw'
-DEFAULT_DATABASE_SCHEMA_VERSION = 'b_add_meeting_summary'
+DEFAULT_DATABASE_SCHEMA_VERSION = 'v0_1_1_add_meeting_summary'
 
 
 class GPUSettings(BaseSettings):


### PR DESCRIPTION
## Summary
- update the default database schema version constant to match the latest Alembic migration identifier

## Testing
- uv run ruff check --fix .
- uv run ruff format .
- uv run mypy .
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc52891758832c954da0ffd320d2aa